### PR TITLE
Notification of authentication.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -26,5 +26,7 @@
     <string name="prefcat_URL_title">URLs to use</string>
     <string name="pref_URLToCheckHTTPS">pref_URLToCheckHTTPS</string>
     <string name="pref_URLToCheckHTTPS_title">HTTPS Url</string>
+    <string name="pref_NotifyAuthentication">pref_NotifyAuthentication</string>
+    <string name="pref_NotifyAuthentication_title">Notify authentication</string>
 
 </resources>

--- a/res/values/wifi_auth_strings.xml
+++ b/res/values/wifi_auth_strings.xml
@@ -35,4 +35,8 @@
     <string name="action_reenable_wifi">com.wifiafterconnect.REENABLE_WIFI</string>
     <string name="label_settings">Settings</string>
     <string name="success_notification">Logged into WiFi network</string>
+    <string name="notif_wifi_auth_title">WiFi authentication</string>
+    <string name="notif_wifi_auth_success">Logged into WiFi network</string>
+    <string name="notif_wifi_auth_inprogress">Authentication in progress</string>
+    <string name="notif_wifi_auth_fail">Authentication failed</string>
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
     <CheckBoxPreference android:summary="@string/pref_enable_background_auth_summary" android:key="@string/pref_EnableBackgroundAuth" android:title="@string/pref_enable_background_auth" android:defaultValue="true"/>
+    <CheckBoxPreference android:key="@string/pref_NotifyAuthentication" android:title="@string/pref_NotifyAuthentication_title" android:defaultValue="false"/>
     <PreferenceCategory android:title="@string/pref_group_locked">
         <CheckBoxPreference android:title="@string/pref_check_autodisable_wifi" android:defaultValue="true" android:key="@string/pref_lockedAutoDisableWifi" android:summary="@string/pref_check_autodisable_wifi_summary" />
         <CheckBoxPreference android:key="@string/pref_ReenableWifiQuiet" android:title="@string/pref_check_reenable_wifi_quiet" android:defaultValue="true" android:summary="@string/pref_check_reenable_wifi_quiet_summary" />

--- a/res/xml/preferences_debug.xml
+++ b/res/xml/preferences_debug.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
-    <CheckBoxPreference android:summary="@string/pref_enable_background_auth_summary" android:key="@string/pref_EnableBackgroundAuth" android:title="@string/pref_enable_background_auth" android:defaultValue="true"/><PreferenceCategory android:title="@string/pref_title_logging" android:summary="@string/pref_logging_summary">
+    <CheckBoxPreference android:summary="@string/pref_enable_background_auth_summary" android:key="@string/pref_EnableBackgroundAuth" android:title="@string/pref_enable_background_auth" android:defaultValue="true"/>
+    <CheckBoxPreference android:key="@string/pref_NotifyAuthentication" android:title="@string/pref_NotifyAuthentication_title" android:defaultValue="false"/>
+    <PreferenceCategory android:title="@string/pref_title_logging" android:summary="@string/pref_logging_summary">
         <CheckBoxPreference android:key="@string/pref_saveLogFileEnable" android:title="@string/pref_label_log_save_enable" android:defaultValue="false" android:summary="@string/pref_label_log_save_enable_summary"/>
         <CheckBoxPreference android:key="@string/pref_saveLogDir" android:title="@string/pref_label_save_location" android:defaultValue="true" android:dependency="@string/pref_saveLogFileEnable"/>
     </PreferenceCategory>

--- a/src/com/wifiafterconnect/util/Preferences.java
+++ b/src/com/wifiafterconnect/util/Preferences.java
@@ -50,6 +50,11 @@ public class Preferences {
 		return sharedPrefs.getBoolean ("pref_ReenableWifiQuiet", true);
 	}
 
+	public boolean getNotifyAuthentication () {
+		SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+		return sharedPrefs.getBoolean ("pref_NotifyAuthentication", true);
+	}
+
 	public URL getURLToCheckHttp  () {
 		SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 		URL url = null;


### PR DESCRIPTION
I dont't know if you're interested, but since the captive portal i use is not detected by android (the wifi icon remains grayed even after Wifi Afterconnect has done its work), i prefer to see a notification when Wifi Afterconnect works... and has finished its authentication. So i propose the following patch to enable notification. Note that these notification can be enabled/disabled in the preference pane.
Feel free to enhance, modify or reject this contribution.
